### PR TITLE
fix(type_conflicts): remove _G from ui.d.ts

### DIFF
--- a/declarations/ui/ui.d.ts
+++ b/declarations/ui/ui.d.ts
@@ -881,7 +881,6 @@ declare namespace WoWAPI {
 /**
  * global lua namespace
  */
-declare const _G: { [prop: string]: any };
 declare const InterfaceOptionsFramePanelContainer: WoWAPI.Region;
 declare const UIParent: WoWAPI.Frame;
 


### PR DESCRIPTION
_G is already included in more complete LUA type libraries. Removing it from here to avoid conflicts.